### PR TITLE
Bugfix: Correct task definition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,9 +163,7 @@ tasks.register('mergeBuild') {
     }
     dependsOn 'buildModel'
     dependsOn 'mergeScripts'
-    tasks.named('buildModel') {
-        mustRunAfter 'mergeScripts'
-    }
+    tasks.findByName('buildModel').mustRunAfter 'mergeScripts'
 }
 
 // Fügt die Skripte zusammen, fügt sie in das Modell ein und läd


### PR DESCRIPTION

## Description

- switchted from named to findByName because it can cause errors
- findByName was already used in all other tasks except for one single spot