### PR TITLE
SBW-32552 | Use parameters.json file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.ResolverStyle
@@ -7,6 +9,8 @@ plugins {
     id 'groovy'
     id 'de.seitenbau.serviceportal.prozesspipeline' version '2025.06.10-0'
 }
+
+initJsonParameters()
 
 repositories {
     mavenCentral()
@@ -49,9 +53,41 @@ sourceSets {
 //    }
 //}
 
+def initJsonParameters()
+{
+    def jsonFilename = project.hasProperty('parameters')
+            ? project.property('parameters')
+            : 'config/parameters.json'
+
+    def jsonParameters
+    def jsonParametersFile = file(jsonFilename)
+    if (jsonParametersFile.exists())
+    {
+        jsonParameters = new JsonSlurper().parseText(jsonParametersFile.text)
+        // merge arrays, e.g. ["a","b","c"], into multi-line strings, e.g. "a\nb\nc"
+        jsonParameters.replaceAll((key, value) -> {
+            if (value instanceof Collection)
+            {
+                return value.join('\n')
+            }
+            return value
+        })
+    }
+    else
+    {
+        jsonParameters = [:]
+    }
+
+    project.ext.set("jsonParameters", jsonParameters)
+}
+
 // Ermittelt für eine Variable Wert bzw. setzt den Defaultwert wenn nicht vorhanden
 def getVariableValue(String name, defaultValue = null) {
-    return project.hasProperty(name) ? project.property(name) : defaultValue
+    def value = project.hasProperty(name)
+            ? project.property(name)
+            : project.jsonParameters[name] ?: defaultValue
+
+    return value;
 }
 
 def getVariableValueAsLocalDate(String name) {

--- a/config/parameters.json.example
+++ b/config/parameters.json.example
@@ -1,0 +1,8 @@
+{
+  "environment": "amt24-develop",
+  "debug": false,
+  "deploymentId": 123,
+  "undeploymentDate": "17.07.2050",
+  "undeploymentAnnounceMessageSubject": "Sample subject",
+  "undeploymentAnnounceMessageBody": "Sample message"
+}


### PR DESCRIPTION
## Description

- Add script to use config/parameters.json as fallback when existent
- Add sample parameters.json file

## How to test

1. Rename the file `parameters.json.example` to `parameters.json`
2. Add a file for the configured `environment` (can be copied from our internal test project)
3. Configure parameters in the new file and  execute `./gradlew getAuth`
4. Configure parameters in the new file and  execute `./gradlew createScheduledUndeployment`